### PR TITLE
Samurai fixes

### DIFF
--- a/src/features/combat/combatSlice.ts
+++ b/src/features/combat/combatSlice.ts
@@ -443,7 +443,7 @@ export const combo =
     dispatch(
       addCombo({
         actionId,
-        timeoutId: setTimeout(() => dispatch(removeCombo(actionId)), 20000),
+        timeoutId: setTimeout(() => dispatch(removeCombo(actionId)), 30000),
       })
     );
   };

--- a/src/features/combat/jobs/sam/SenGauge.tsx
+++ b/src/features/combat/jobs/sam/SenGauge.tsx
@@ -11,11 +11,16 @@ export const SenGauge = () => {
   const kaColor = '#E2837E';
   const emptyColor = '#0D1932';
 
+  /* Sen can take the base 10 integer values 0, 1, 10, 11, 100, 110, 111.
+   * If the ones digit is 1, then the yukikaze (setsu) sen is present.
+   * If the tens digit is 1, then the gekko (getsu) sen is present.
+   * If the 100s digit is 1, then the kasha (ka) sen is present.
+   */
   return (
     <HudItem name="SenGauge" defaultPosition={{ x: 20, y: 20 }}>
       <div className="grid grid-flow-col auto-cols-max gap-1.5">
         <FontAwesomeIcon icon={faSnowflake} color={sen % 10 > 0 ? setsuColor : emptyColor} />
-        <FontAwesomeIcon icon={faMoon} color={sen % 100 > 0 ? getsuColor : emptyColor} />
+        <FontAwesomeIcon icon={faMoon} color={sen % 100 >= 10 ? getsuColor : emptyColor} />
         <FontAwesomeIcon icon={faClover} color={sen >= 100 ? kaColor : emptyColor} />
       </div>
     </HudItem>

--- a/src/features/combat/jobs/sam/sam.ts
+++ b/src/features/combat/jobs/sam/sam.ts
@@ -247,7 +247,7 @@ const yukikaze: CombatAction = createCombatAction({
   id: ActionId.Yukikaze,
   execute: (dispatch, getState, context) => {
     if (context.comboed || hasBuff(getState(), StatusId.MeikyoShisui)) {
-      dispatch(addKenki(10));
+      dispatch(addKenki(15));
       dispatch(addSen(ActionId.Yukikaze));
     }
   },

--- a/src/features/combat/jobs/sam/sam.ts
+++ b/src/features/combat/jobs/sam/sam.ts
@@ -528,7 +528,7 @@ const fuko: CombatAction = createCombatAction({
   execute: (dispatch) => {
     dispatch(combo(ActionId.Fuga));
 
-    dispatch(addKenki(5));
+    dispatch(addKenki(10));
   },
   reducedBySkillSpeed: true,
 });

--- a/src/features/combat/jobs/sam/sam.ts
+++ b/src/features/combat/jobs/sam/sam.ts
@@ -88,6 +88,7 @@ const consumeMeikyoEpic: Epic<any, any, RootState> = (action$) =>
               ActionId.KaeshiHiganbana,
               ActionId.KaeshiSetsugekka,
               ActionId.KaeshiGoken,
+              ActionId.Enpi,
             ].includes(aa.payload.id)
         ),
         takeUntil(action$.pipe(first((a) => a.type === removeBuff.type && a.payload === a.payload.id)))


### PR DESCRIPTION
1. There is a visual error where the sen gauge displays both "getsu" and "setsu" sen when only the "setsu" sen should be displayed.
2. Enpi should not consume stacks of meikyo shisui. This was changed in 6.1, "ranged weaponskills no longer count toward the effect of this action." The official job guide tooltip is wrong.

The result of my basic testing is as follows:
1. Enpi does not consume meikyo
2. Enhanced enpi does not consume meikyo
3. Comboed yukikaze does not light up the getsu sen
4. All sen orders seem to light up properly

By all means sanity check / run any test suites you have, but it's 2 lines and I'm pretty sure the changes are correct.